### PR TITLE
Change screen breakpoint to hide hamburger menu

### DIFF
--- a/public/fair-rate-mortgage/index.html
+++ b/public/fair-rate-mortgage/index.html
@@ -34,7 +34,7 @@
         </a>
       </div>
 
-      <div class="w-1/2 text-right sm:hidden">
+      <div class="w-1/2 text-right md:hidden">
         <button type="button" class="navbar-toggler">
           <span class="navbar-toggler-bar"></span>
           <span class="navbar-toggler-bar"></span>


### PR DESCRIPTION
Hi @iamsahilvhora,

First of all, thanks for your cool landing page examples using tailwindCSS. 

Regarding your fair-rate-mortgage template (https://tailwindcss-templates.netlify.com/fair-rate-mortgage/), I found that for screen widths between 640px (sm) and 768px (md) there are no nav items available in your navbar: the hamburger menu is being hidden for breakpoint 'sm', however your navigation items are only being displayed for breakpoint 'md'. I have created a small pull request to correct this behaviour. Please have a look at it :).

Thanks and Regards,
Alex